### PR TITLE
Update cl-ascii-table.asd

### DIFF
--- a/cl-ascii-table.asd
+++ b/cl-ascii-table.asd
@@ -1,9 +1,9 @@
 ;;;; cl-ascii-table.asd
 
 (asdf:defsystem #:cl-ascii-table
-  :description "Describe cl-ascii-table here"
-  :author "Your Name <your.name@example.com>"
-  :license "Specify license here"
+  :description "Common Lisp library to present tabular data in ascii-art table."
+  :author "Philippe MECHAI"
+  :license "MIT"
   :serial t
   :components ((:file "package")
                (:file "cl-ascii-table")))


### PR DESCRIPTION
Filled out info fields in system definition. They're wanted for inclusion in quicklisp. The author field probably needs attention.