### PR TITLE
Added a way to define custom formatter for each field

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -7,6 +7,7 @@
      #:make-table
      #:add-row
      #:add-separator
+     #:*default-value-formatter*
      #:display))
 
 


### PR DESCRIPTION
It might be useful, for example, if you want to render float numbers
with a limited number of digits after the point.

This can be done like that:

```lisp
CL-USER> (let ((ascii-table:*default-value-formatter*
                 (lambda (value)
                   (format nil
                           (typecase value
                             (double-float "~,2F")
                             (t "~A"))
                           value))))
             (let ((ascii (ascii-table:make-table '("Name" "Value"))))
               (ascii-table:add-row ascii
                                    (list "Pi" pi))
               (ascii-table:display ascii t)))
+------+-------+
| Name | Value |
+------+-------+
| Pi   |  3.14 |
+------+-------+
```